### PR TITLE
control concurrency for RequestStream

### DIFF
--- a/bin/cflogreplay
+++ b/bin/cflogreplay
@@ -3,14 +3,15 @@
 var keepalive = require('agentkeepalive');
 var split = require('split');
 var reader = require('..');
+var args = require('minimist')(process.argv.slice(2));
 
-var baseurl = process.argv[2];
-if (!baseurl) {
-  console.error('Usage: cflogreplay <baseurl>');
+var baseurl = args._[0];
+if (!baseurl || baseurl.indexOf('http') == -1) {
+  console.error('Usage: cflogreplay <baseurl> [--concurrency=<n>]');
   process.exit(1);
 }
 
-var hwm = parseInt(process.argv[3]) ? parseInt(process.argv[3]) : null;
+var hwm = parseInt(args.concurrency) ? parseInt(args.concurrency) : null;
 
 var agentType = /http:/.test(baseurl)? keepalive : keepalive.HttpsAgent;
 var agent = new agentType({

--- a/bin/cflogreplay
+++ b/bin/cflogreplay
@@ -10,6 +10,8 @@ if (!baseurl) {
   process.exit(1);
 }
 
+var hwm = parseInt(process.argv[3]) ? parseInt(process.argv[3]) : null;
+
 var agentType = /http:/.test(baseurl)? keepalive : keepalive.HttpsAgent;
 var agent = new agentType({
     keepAlive: true,
@@ -18,7 +20,7 @@ var agent = new agentType({
 });
 
 var generatePath = reader.GeneratePath('cloudfront');
-var reqStream = reader.RequestStream({ baseurl: baseurl, agent: agent });
+var reqStream = reader.RequestStream({ baseurl: baseurl, agent: agent, hwm: hwm });
 process.stdin
     .pipe(split())
     .pipe(generatePath)

--- a/index.js
+++ b/index.js
@@ -80,13 +80,14 @@ function GeneratePath(type) {
 function RequestStream(options) {
     options = options || {};
     if (!options.baseurl) throw new Error('options.baseurl should be an http:// or https:// baseurl for replay requests');
+    if (!options.hwm) options.hwm = 100;
 
     var starttime = Date.now();
     var requestStream = new stream.Transform(options);
     requestStream._readableState.objectMode = true;
     requestStream.got = 0;
     requestStream.pending = 0;
-    requestStream.queue = queue();
+    requestStream.queue = queue(options.hwm);
     requestStream.queue.awaitAll(function(err) {
         if (err) requestStream.emit('error', err);
     });
@@ -97,7 +98,7 @@ function RequestStream(options) {
 
         var uri = url.parse(pathname, true);
 
-        if (requestStream.pending > 1000) {
+        if (requestStream.pending > (options.hwm * 1.5)) {
             return setImmediate(requestStream._transform.bind(requestStream), pathname, enc, callback);
         }
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "readmeFilename": "README.md",
   "dependencies": {
     "agentkeepalive": "^2.0.3",
+    "minimist": "^1.2.0",
     "queue-async": "1.0.x",
     "requestretry": "1.5.x",
     "s3scan": "0.1.x",

--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,14 @@ Streams CF log lines to `stdout`.
 Usage: cflogreader <s3url>
 ```
 
+### generatepath
+
+Takes different types of logs as input and streams paths to `stdout`.
+
+```sh
+Usage: generatepath <type>
+```
+
 ### cflogreplay
 
 Makes replay requests to the `baseurl`. Expects CF log lines to be piped to `stdin`. (Optional) Control concurrency of replay requests with `--concurrency` flag. Default is 100.
@@ -25,4 +33,3 @@ Makes replay requests to the `baseurl`. Expects CF log lines to be piped to `std
 ```sh
 Usage: cflogreplay <baseurl> [--concurrency=<n>]
 ```
-

--- a/readme.md
+++ b/readme.md
@@ -20,9 +20,9 @@ Usage: cflogreader <s3url>
 
 ### cflogreplay
 
-Makes replay requests to the `baseurl`. Expects CF log lines to be piped to `stdin`.
+Makes replay requests to the `baseurl`. Expects CF log lines to be piped to `stdin`. (Optional) Control concurrency of replay requests with `--concurrency` flag. Default is 100.
 
 ```sh
-Usage: cflogreplay <baseurl>
+Usage: cflogreplay <baseurl> [--concurrency=<n>]
 ```
 

--- a/test/RequestStream.test.js
+++ b/test/RequestStream.test.js
@@ -3,18 +3,46 @@ var reader = require('../index.js');
 var tape = require('tape');
 var http = require('http');
 var server;
+var count = 0;
 
 tape('setup', function(assert) {
     server = http.createServer(function(req, res) {
+        count++;
         if (/\/c\.json/.test(req.url)) {
             res.writeHead(404);
         } else {
             res.writeHead(200);
             res.write(JSON.stringify({ obj: req.url.split('/')[1].split('.')[0] }));
         }
-        res.end();
+        setTimeout(function() {
+            res.end();
+        }, 1000);
     });
     server.listen(9999, assert.end);
+});
+
+tape('RequestStream [concurrency]', function(assert) {
+    var reqstream = reader.RequestStream({
+        baseurl: 'http://localhost:9999',
+        hwm: 3
+    });
+    reqstream.on('data', function(d) { 
+    });
+    reqstream.on('end', function() { 
+        assert.end();
+    });
+    var req = 0;
+    var j = setInterval(function() {
+        req = req + 3;
+        assert.equal(req, count);
+    }, 1000);
+    for (var i = 0; i < 10; i++) {
+        reqstream.write('/a.json?option=1\n');
+    }
+    setTimeout(function() {
+        clearInterval(j);
+        reqstream.end();
+    }, 3500);
 });
 
 tape('RequestStream', function(assert) {

--- a/test/bin.test.js
+++ b/test/bin.test.js
@@ -23,13 +23,13 @@ tape('setup', function(assert) {
 tape('cflogreplay: usage', function(assert) {
     exec(__dirname + '/../bin/cflogreplay', {env:process.env}, function(err, stdout, stderr) {
         assert.equal(err.code, 1, 'exits 1');
-        assert.equal(stderr, 'Usage: cflogreplay <baseurl>\n', 'shows usage');
+        assert.equal(stderr, 'Usage: cflogreplay <baseurl> [--concurrency=<n>]\n', 'shows usage');
         assert.end();
     });
 });
 
 tape('cflogreplay', function(assert) {
-    var child = spawn(__dirname + '/../bin/cflogreplay', ['http://localhost:9999', 'foobar']);
+    var child = spawn(__dirname + '/../bin/cflogreplay', ['http://localhost:9999']);
     var data = [];
     child.stdout.on('data', function(d) {
         data.push(d.toString());
@@ -45,6 +45,34 @@ tape('cflogreplay', function(assert) {
     child.stdin.write('2014-09-05	12:48:00	IAD53	33125	54.236.254.12	GET	d3eju24r2ptc5d.cloudfront.net	/a.json	200	https://www.mapbox.com/	FakeAgent	option=1	-	Miss	FAKE==	example.com	http	784	0.314\n');
     child.stdin.write('2014-09-05	12:48:00	IAD53	33125	54.236.254.12	GET	d3eju24r2ptc5d.cloudfront.net	/b.json	200	https://www.mapbox.com/	FakeAgent	option=2	-	Miss	FAKE==	example.com	http	784	0.314\n');
     child.stdin.write('2014-09-05	12:48:00	IAD53	33125	54.236.254.12	GET	d3eju24r2ptc5d.cloudfront.net	/c.json	200	https://www.mapbox.com/	FakeAgent	option=2	-	Miss	FAKE==	example.com	http	784	0.314\n');
+    child.stdin.write('\n');
+    child.stdin.end();
+});
+
+tape('cflogreplay [bad args]', function(assert) {
+    var child = spawn(__dirname + '/../bin/cflogreplay', ['foobar', 'http://localhost:9999']);
+    var data = [];
+    child.stderr.on('data', function(data) {
+        assert.equal(data.toString(), 'Usage: cflogreplay <baseurl> [--concurrency=<n>]\n', 'Usage when args out of order');
+        assert.end();
+    });
+});
+
+tape('cflogreplay [concurrency arg]', function(assert) {
+    var child = spawn(__dirname + '/../bin/cflogreplay', ['http://localhost:9999', '--concurrency=5']);
+    var data = [];
+    child.stdout.on('data', function(d) {
+        data.push(d.toString());
+    });
+    child.stderr.on('data', function(data) {
+        assert.ifError(data);
+    });
+    child.on('close', function(code) {
+        assert.deepEqual(data, ['{"obj":"a"}\n'], 'emits obj a');
+        assert.equal(code, 0, 'exits 0');
+        assert.end();
+    });
+    child.stdin.write('2014-09-05	12:48:00	IAD53	33125	54.236.254.12	GET	d3eju24r2ptc5d.cloudfront.net	/a.json	200	https://www.mapbox.com/	FakeAgent	option=1	-	Miss	FAKE==	example.com	http	784	0.314\n');
     child.stdin.write('\n');
     child.stdin.end();
 });

--- a/test/bin.test.js
+++ b/test/bin.test.js
@@ -29,7 +29,7 @@ tape('cflogreplay: usage', function(assert) {
 });
 
 tape('cflogreplay', function(assert) {
-    var child = spawn(__dirname + '/../bin/cflogreplay', ['http://localhost:9999']);
+    var child = spawn(__dirname + '/../bin/cflogreplay', ['http://localhost:9999', 'foobar']);
     var data = [];
     child.stdout.on('data', function(d) {
         data.push(d.toString());


### PR DESCRIPTION
fixes https://github.com/mapbox/cloudfront-log-reader/issues/13, implemented via https://github.com/mapbox/cloudfront-log-reader/issues/13#issuecomment-170082542

cflogreplay takes optional 2nd argument for concurrency of request stream.

cc @yhahn 