### PR TITLE
elb mode for GeneratePath

### DIFF
--- a/bin/generatepath
+++ b/bin/generatepath
@@ -5,9 +5,9 @@ var split = require('split');
 var reader = require('..');
 
 var type = process.argv[2];
-if (!type || type !== 'cloudfront') {
+if (!type || (type !== 'cloudfront' && type !== 'elb')) {
   console.error('Usage: generatepath <type>');
-  console.error('<type> can be "cloudfront"');
+  console.error('<type> can be "cloudfront" or "elb"');
   process.exit(1);
 }
 

--- a/index.js
+++ b/index.js
@@ -65,6 +65,15 @@ function GeneratePath(type) {
                     generatePath.push(parts[7]);
                 }
             }
+        } else if (type.toLowerCase() == 'elb') {
+            if (line.indexOf('Amazon Route 53 Health Check Service') > -1) return callback();
+            var parts = line.split(/\s+/g);
+            if (parts.length < 12) return callback();
+            var path = parts[12]
+            path = path.split('443')[1];
+            if (!path) return callback();
+            if (path.length < 2) return callback();
+            generatePath.push(path);
         }
         callback();
     };

--- a/index.js
+++ b/index.js
@@ -69,10 +69,9 @@ function GeneratePath(type) {
             if (line.indexOf('Amazon Route 53 Health Check Service') > -1) return callback();
             var parts = line.split(/\s+/g);
             if (parts.length < 12) return callback();
-            var path = parts[12]
-            path = path.split('443')[1];
+            var path = parts[12];
+            path = path.split(/:[0-9]\w+/g)[1];
             if (!path) return callback();
-            if (path.length < 2) return callback();
             generatePath.push(path);
         }
         callback();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudfront-log-reader",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Read CloudFront logs files stored in AWS S3",
   "main": "index.js",
   "repository": "",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudfront-log-reader",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Read CloudFront logs files stored in AWS S3",
   "main": "index.js",
   "repository": "",

--- a/test/GeneratePath.test.js
+++ b/test/GeneratePath.test.js
@@ -26,10 +26,13 @@ tape('GeneratePath [elb]', function(assert) {
     });
     generatePath.on('end', function() {
         assert.equal(data[0], '/a.json?option=1');
-        assert.equal(data.length, 1);
+        assert.equal(data[1], '/b.json?option=1&other=2');
+        assert.equal(data.length, 2);
         assert.end();
     });
-    generatePath.write('\n');
+    generatePath.write('2016-02-01T19:04:59.488164Z eggs-VPC 000.000.000.00:00000 00.0.00.00:00 0.000024 0.006806 0.00002 304 304 0 0 "GET http://green-eggs.com:80/a.json?option=1 HTTP/1.1" "Amazon CloudFront" - -');
+    generatePath.write('2016-02-01T19:04:59.488164Z eggs-VPC 000.000.000.00:00000 00.0.00.00:00 0.000024 0.006806 0.00002 200 200 0 0 "GET http://green-eggs.com:666/b.json?option=1&other=2 HTTP/1.1" "Amazon CloudFront" - -');
+    generatePath.write('us-east-1.elb.amazonaws.com:666/ HTTP/1.1" "Amazon Route 53 Health Check Service; ref:000-000-0000; report http://green.eggs" ABCD-EFGH TLSv1.2');
     generatePath.write('\n');
     generatePath.end();
 });

--- a/test/GeneratePath.test.js
+++ b/test/GeneratePath.test.js
@@ -17,3 +17,19 @@ tape('GeneratePath [cloudfront]', function(assert) {
     generatePath.write('\n');
     generatePath.end();
 });
+
+tape('GeneratePath [elb]', function(assert) {
+    var data = [];
+    var generatePath = reader.GeneratePath('elb');
+    generatePath.on('data', function(d) {
+        data.push(d);
+    });
+    generatePath.on('end', function() {
+        assert.equal(data[0], '/a.json?option=1');
+        assert.equal(data.length, 1);
+        assert.end();
+    });
+    generatePath.write('\n');
+    generatePath.write('\n');
+    generatePath.end();
+});

--- a/test/bin.test.js
+++ b/test/bin.test.js
@@ -115,12 +115,12 @@ tape('cflogreader', function(assert) {
 tape('generatepath: usage', function(assert) {
     exec(__dirname + '/../bin/generatepath', {env:process.env}, function(err, stdout, stderr) {
         assert.equal(err.code, 1, 'exits 1');
-        assert.equal(stderr, 'Usage: generatepath <type>\n<type> can be "cloudfront"\n', 'shows usage');
+        assert.equal(stderr, 'Usage: generatepath <type>\n<type> can be "cloudfront" or "elb"\n', 'shows usage');
         assert.end();
     });
 });
 
-tape('generatepath', function(assert) {
+tape('generatepath [cloudfront]', function(assert) {
     var child = spawn(__dirname + '/../bin/generatepath', ['cloudfront']);
     var data = [];
     child.stdout.on('data', function(d) {
@@ -130,15 +130,34 @@ tape('generatepath', function(assert) {
         assert.ifError(data);
     });
     child.on('close', function(code) {
-        assert.equal(data[0], '/a.json?option=1\n')
-        assert.equal(data[1], '/b.json?option=2\n')
-        assert.equal(data[2], '/c.json?option=2\n')
+        assert.equal(data[0], '/a.json?option=1\n');
+        assert.equal(data[1], '/b.json?option=2\n');
+        assert.equal(data[2], '/c.json?option=2\n');
         assert.equal(code, 0, 'exits 0');
         assert.end();
     });
     child.stdin.write('2014-09-05	12:48:00	IAD53	33125	54.236.254.12	GET	d3eju24r2ptc5d.cloudfront.net	/a.json	200	https://www.mapbox.com/	FakeAgent	option=1	-	Miss	FAKE==	example.com	http	784	0.314\n');
     child.stdin.write('2014-09-05	12:48:00	IAD53	33125	54.236.254.12	GET	d3eju24r2ptc5d.cloudfront.net	/b.json	200	https://www.mapbox.com/	FakeAgent	option=2	-	Miss	FAKE==	example.com	http	784	0.314\n');
     child.stdin.write('2014-09-05	12:48:00	IAD53	33125	54.236.254.12	GET	d3eju24r2ptc5d.cloudfront.net	/c.json	200	https://www.mapbox.com/	FakeAgent	option=2	-	Miss	FAKE==	example.com	http	784	0.314\n');
+    child.stdin.write('\n');
+    child.stdin.end(); 
+});
+
+tape('generatepath [cloudfront]', function(assert) {
+    var child = spawn(__dirname + '/../bin/generatepath', ['elb']);
+    var data = [];
+    child.stdout.on('data', function(d) {
+        data.push(d.toString());
+    });
+    child.stderr.on('data', function(data) {
+        assert.ifError(data);
+    });
+    child.on('close', function(code) {
+        assert.equal(data[0], '/a.json?option=1\n');
+        assert.equal(code, 0, 'exits 0');
+        assert.end();
+    });
+    child.stdin.write('2016-02-01T19:04:59.488164Z eggs-VPC 000.000.000.00:00000 00.0.00.00:00 0.000024 0.006806 0.00002 304 304 0 0 "GET http://green-eggs.com:80/a.json?option=1 HTTP/1.1" "Amazon CloudFront" - -\n');
     child.stdin.write('\n');
     child.stdin.end(); 
 });


### PR DESCRIPTION
closes https://github.com/mapbox/cloudfront-log-reader/issues/14

`generatepath` (or the original GeneratePath stream) can now be used to filter ELB logs.

cc @yhahn 