### PR TITLE
sampling

### DIFF
--- a/bin/sample
+++ b/bin/sample
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+
+var reader = require('..');
+var split = require('split');
+var argv = require('minimist')(process.argv.slice(2));
+
+if (!argv.sample) {
+  console.error('Usage: sample --rate=<f> [--filter=<s>]');
+  process.exit(1);
+}
+
+var sampleStream = reader.SampleStream({ rate: argv.rate, filter: argv.filter || false });
+process.stdin
+    .pipe(split())
+    .pipe(sampleStream)
+    .on('error', function(err) {
+        console.error(err);
+        process.exit(1);
+    })
+    .on('data', function(data) {
+        console.log(data.toString('utf8'));
+    });

--- a/bin/sample
+++ b/bin/sample
@@ -4,7 +4,7 @@ var reader = require('..');
 var split = require('split');
 var argv = require('minimist')(process.argv.slice(2));
 
-if (!argv.sample) {
+if (!argv.rate) {
   console.error('Usage: sample --rate=<f> [--filter=<s>]');
   process.exit(1);
 }

--- a/index.js
+++ b/index.js
@@ -169,9 +169,5 @@ function SampleStream(options) {
         callback();
     };
 
-    sampleStream._flush = function(callback) {
-        callback();
-    };
-
     return sampleStream;
 }

--- a/readme.md
+++ b/readme.md
@@ -33,3 +33,11 @@ Makes replay requests to the `baseurl`. Expects paths to be piped to `stdin`. (O
 ```sh
 Usage: pathreplay <baseurl> [--concurrency=<n>]
 ```
+
+### sample
+
+Emits a repeatable set of input lines piped to `stdin` at a given sampling rate. The number of lines emitted will approach the specific rate over sufficiently large samples, but may diverge for small sample sizes. Sampling rates should be specified as a decimal number between zero and one. Optionally accepts a `filter` argument that restricts the sampled set to lines matching the specified regular expression.
+
+```sh
+Usage: sample --rate=<rate> [--filter=<filter>]
+```

--- a/test/SampleStream.test.js
+++ b/test/SampleStream.test.js
@@ -1,0 +1,41 @@
+var reader = require('..');
+var tape = require('tape');
+var fs = require('fs');
+var split = require('split');
+
+function testFunc(r, f, expected, t) {
+    var sample = reader.SampleStream({ rate: (r * 0.1), filter: f });
+    var scanGunzip = reader.ScanGunzip();
+
+    var count = 0;
+    sample.on('data', function(data) {
+        count++;
+    });
+    sample.on('finish', function() {
+        t.equals(count, expected[r - 1], 'got expected records (' + expected[r - 1] + ')');
+        t.end();
+    });
+
+    scanGunzip
+        .pipe(split())
+        .pipe(sample);
+
+    for (var k = 0; k < 1000; k++) {
+        // each of these is 9 records long
+        scanGunzip.write({
+            Body: fs.readFileSync(__dirname + '/fixtures/AAAAAAAAAAAAAA.2015-10-19-17.e5b6526a.gz')
+        });
+    }
+    scanGunzip.end();
+}
+
+var expectedUnfiltered = [949, 1879, 2820, 3728, 4592, 5449, 6323, 7220, 8136];
+for (var rate = 1; rate < 10; rate++) {
+    tape('unfiltered, sample rate ' + (rate * 0.1).toFixed(1), testFunc.bind(null, rate, false, expectedUnfiltered));
+}
+
+var expectedFiltered = [299, 607, 904, 1218, 1509, 1788, 2085, 2384, 2716];
+for (var rate = 1; rate < 10; rate++) {
+    tape('filtered, sample rate ' + (rate * 0.1).toFixed(1), testFunc.bind(null, rate, 'a\.json', expectedFiltered));
+}
+

--- a/test/SampleStream.test.js
+++ b/test/SampleStream.test.js
@@ -12,7 +12,7 @@ function testFunc(r, f, expected, t) {
         count++;
     });
     sample.on('finish', function() {
-        t.equals(count, expected[r - 1], 'got expected records (' + expected[r - 1] + ')');
+        t.equals(count, expected, 'got expected records (' + expected + ')');
         t.end();
     });
 
@@ -31,11 +31,11 @@ function testFunc(r, f, expected, t) {
 
 var expectedUnfiltered = [949, 1879, 2820, 3728, 4592, 5449, 6323, 7220, 8136];
 for (var rate = 1; rate < 10; rate++) {
-    tape('unfiltered, sample rate ' + (rate * 0.1).toFixed(1), testFunc.bind(null, rate, false, expectedUnfiltered));
+    tape('unfiltered, sample rate ' + (rate * 0.1).toFixed(1), testFunc.bind(null, rate, false, expectedUnfiltered[rate - 1]));
 }
 
 var expectedFiltered = [299, 607, 904, 1218, 1509, 1788, 2085, 2384, 2716];
 for (var rate = 1; rate < 10; rate++) {
-    tape('filtered, sample rate ' + (rate * 0.1).toFixed(1), testFunc.bind(null, rate, 'a\.json', expectedFiltered));
+    tape('filtered, sample rate ' + (rate * 0.1).toFixed(1), testFunc.bind(null, rate, 'a\.json', expectedFiltered[rate - 1]));
 }
 


### PR DESCRIPTION
Provides a convenience function & script for taking a percentage of incoming records. Main advantage over simpler implementations is deterministic behavior: for a given sample rate, the same rows will always be returned.

@ianshward this is a component of what we discussed in chat and can be chained with the repo's existing scripts. But it doesn't include the random selection of cloudfront log files that you had mentioned as part of the solution you envisioned. This gets us partway there, though (and is probably all I need for my first pass). Let me know what you think!