### PR TITLE
feat: per-request data.headers in RequestStream

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file. For change log formatting, see http://keepachangelog.com/
 
+## Unreleased
+- `RequestStream` merges optional per-request `data.headers` onto each replayed HTTP request (on top of `options.headers` / `referer`)
+
 ## 4.2.0
 - Adds `safe-regex2` to check for unsafe regexes in SampleStream filter input
 - Throws an error on lines bigger than 1KB to prevent potential resource exhaustion

--- a/index.js
+++ b/index.js
@@ -85,7 +85,12 @@ function GeneratePath(type, keepReferer = false) {
  * @param {object} options
  * @param {string} options.baseurl - Required. An http or https url prepended to paths when making requests.
  * @param {string} options.strictSSL - Optional. If true (default), requires SSL/TLS certificates to be valid
- * @param {object} options.headers - Optional. Headers to applied to requests
+ * @param {object} options.headers - Optional. Headers applied to every request
+ *
+ * Each input object may include:
+ * - path (required), method, referer
+ * - headers (optional object): per-request headers merged on top of options.headers
+ *   (e.g. { 'x-mapbox-request-id': '...' } for wiretap Refresh/CA replay)
  */
 function RequestStream(options) {
   options = options || {};
@@ -142,13 +147,14 @@ function RequestStream(options) {
       }
     }
 
-    if (referer) {
-      gotOptions.headers = { referer };
+    var headers = {};
+    if (referer) headers.referer = referer;
+    if (options.headers) headers = { ...headers, ...options.headers };
+    // Per-request headers win over static options.headers for the same key.
+    if (data.headers && typeof data.headers === 'object') {
+      headers = { ...headers, ...data.headers };
     }
-
-    if(options.headers) {
-      gotOptions.headers = { ...gotOptions.headers, ...options.headers };
-    }
+    if (Object.keys(headers).length > 0) gotOptions.headers = headers;
 
     got(url, gotOptions)
       .then(({ statusCode, body, timings }) => {

--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,8 @@ Takes different types of logs as input and streams  an object to `stdout`. Forma
 ```
 Supported types include "cloudfront" for CloudFront logs and "lb" for ELB Classic or ALB logs.
 
+When feeding objects into `RequestStream` programmatically, you may also include a `headers` object for per-request HTTP headers (merged on top of `RequestStream({ headers })` static headers). Example: `{ path: '/a', method: 'GET', headers: { 'x-mapbox-request-id': '...' } }`.
+
 ```sh
 Usage: generatepath <type>
 ```

--- a/test/RequestStream.test.js
+++ b/test/RequestStream.test.js
@@ -235,6 +235,55 @@ tape('RequestStream SSRF protection - valid relative paths still work', function
   reqstream.end();
 });
 
+tape('RequestStream per-request data.headers', function(assert) {
+  server.reset();
+  var seen = [];
+  var headerServer = http.createServer(function(req, res) {
+    seen.push({
+      url: req.url,
+      requestId: req.headers['x-mapbox-request-id'],
+      staticHeader: req.headers['x-static'],
+      referer: req.headers.referer
+    });
+    res.writeHead(200);
+    res.end('ok');
+  });
+
+  headerServer.listen(0, '127.0.0.1', function() {
+    var port = headerServer.address().port;
+    var reqstream = reader.RequestStream({
+      baseurl: 'http://127.0.0.1:' + port,
+      headers: { 'x-static': 'always' }
+    });
+
+    reqstream.on('data', function() {});
+    reqstream.on('finish', function() {
+      assert.equal(seen.length, 2);
+      assert.equal(seen[0].requestId, 'id-one');
+      assert.equal(seen[0].staticHeader, 'always');
+      assert.equal(seen[0].referer, 'https://example.com/');
+      assert.equal(seen[1].requestId, 'id-two');
+      assert.equal(seen[1].staticHeader, 'always');
+      // Per-request headers override static options.headers for the same key.
+      assert.equal(seen[1].referer, undefined);
+      headerServer.close(assert.end);
+    });
+
+    reqstream.write({
+      path: '/one',
+      method: 'GET',
+      referer: 'https://example.com/',
+      headers: { 'x-mapbox-request-id': 'id-one' }
+    });
+    reqstream.write({
+      path: '/two',
+      method: 'GET',
+      headers: { 'x-mapbox-request-id': 'id-two' }
+    });
+    reqstream.end();
+  });
+});
+
 tape('teardown', function(assert) {
   server.close(assert.end);
 });


### PR DESCRIPTION
## Summary

- `RequestStream` now merges optional `data.headers` onto each replayed HTTP request.
- Merge order: `referer` → `options.headers` (static) → `data.headers` (per-request wins on key conflicts).
- Enables consumers to forward production request IDs without a local burst-mode fork of this stream.

## Example

```js
RequestStream({ baseurl, headers: { 'x-static': 'auth' } })
// write:
{ path: '/a', method: 'GET', headers: { 'x-mapbox-request-id': 'cf-id-from-log' } }
```

## Test plan

- [x] New unit test asserts static + per-request headers (and referer) on the wire
- [x] Existing `RequestStream` tests still pass (`npx tape test/RequestStream.test.js`)